### PR TITLE
output path bug fixed (without input path now)

### DIFF
--- a/src/tasks/MixJadeTask.js
+++ b/src/tasks/MixJadeTask.js
@@ -126,7 +126,8 @@ class MixJadeTask extends Task {
 
     prepareAssets(src) {
         let file = new File(src);
-        let folder = file.filePath.replace(this.src, '').replace(file.name(), '');
+        let input = this.src.replace(/\//g, '\\');
+        let folder = file.filePath.replace(input, '').replace(file.name(), '');
         let output = path.join(this.dest, folder, file.nameWithoutExtension() + '.blade.php');
         let asset = new File(output);
         Mix.addAsset(asset);


### PR DESCRIPTION
this.src contains input path with / slashes, file.filePath contains \ slashes, so this command will not delete this.src string from output path string:
`
let folder = file.filePath.replace(this.src, '').replace(file.name(), '');
`

For example, if I would type this command in my webpack.min.js
`
mix.jade('public/jade/', 'resources/views/');
`
my blade file (e.g. index.jade) will be placed in this path: "resources/views/public/jade/index.blade.php" but I expected path "resources/views/index.blade.php" ('public/jade/' didn't replace in my output folder string cause of slashes)